### PR TITLE
✨️Feat : S3 이미지 업로드 추가 #35

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
 
     // 테스트에서 사용할 H2 DB 의존성 추가
     runtimeOnly 'com.h2database:h2'
+
+    // aws image
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/campro/onboarding/application/DTO/OnboardingListDTO.java
+++ b/src/main/java/com/campro/onboarding/application/DTO/OnboardingListDTO.java
@@ -7,19 +7,19 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class OnboardingListDTO {
-    private final Long borad_id;
+    private final Long board_id;
     private final String question;
 
     private final List<ChoiceListDTO> choices;
 
-    public OnboardingListDTO(Long borad_id, String question, List<ChoiceListDTO> choices) {
-        this.borad_id = borad_id;
+    public OnboardingListDTO(Long boardId, String question, List<ChoiceListDTO> choices) {
+        board_id = boardId;
         this.question = question;
         this.choices = choices;
     }
 
-    public Long getBorad_id() {
-        return borad_id;
+    public Long getBoard_id() {
+        return board_id;
     }
 
     public String getQuestion() {

--- a/src/main/java/com/campro/s3/S3Configuration.java
+++ b/src/main/java/com/campro/s3/S3Configuration.java
@@ -1,0 +1,35 @@
+package com.campro.s3;
+
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Configuration {
+
+    @Value("${spring.cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${spring.cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return (AmazonS3Client) AmazonS3ClientBuilder
+                .standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .build();
+    }
+
+}

--- a/src/main/java/com/campro/s3/application/DTO/ImageListDTO.java
+++ b/src/main/java/com/campro/s3/application/DTO/ImageListDTO.java
@@ -1,0 +1,29 @@
+package com.campro.s3.application.DTO;
+
+import java.util.Date;
+
+public class ImageListDTO {
+
+    private final String originFileName ;
+    private final String uploadFileName;
+
+    private final Date enroll_date;
+
+    public ImageListDTO(String originFileName, String uploadFileName, Date enroll_date) {
+        this.originFileName = originFileName;
+        this.uploadFileName = uploadFileName;
+        this.enroll_date = enroll_date;
+    }
+
+    public String getOriginFileName() {
+        return originFileName;
+    }
+
+    public String getUploadFileName() {
+        return uploadFileName;
+    }
+
+    public Date getEnroll_date() {
+        return enroll_date;
+    }
+}

--- a/src/main/java/com/campro/s3/application/S3UploadService.java
+++ b/src/main/java/com/campro/s3/application/S3UploadService.java
@@ -1,0 +1,74 @@
+package com.campro.s3.application;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.campro.s3.application.DTO.ImageListDTO;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+
+@Service
+public class S3UploadService {
+    private final AmazonS3 amazonS3;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public S3UploadService(AmazonS3 amazonS3) {
+        this.amazonS3 = amazonS3;
+    }
+
+    public List<ImageListDTO> saveFiles(List<MultipartFile> multipartFile) throws IOException {
+
+        List<ImageListDTO> imageList = new ArrayList<>();
+        for (MultipartFile file : multipartFile) {
+            if(!file.getOriginalFilename().equals("")) {
+                String originalFilename = file.getOriginalFilename();
+                String fileName = createFileName(originalFilename);
+                ObjectMetadata metadata = new ObjectMetadata();
+                metadata.setContentLength(file.getSize());
+                metadata.setContentType(file.getContentType());
+                amazonS3.putObject(bucket, fileName, file.getInputStream(), metadata);
+                imageList.add(new ImageListDTO(originalFilename, amazonS3.getUrl(bucket, fileName).toString(), new Date()));
+            }else{
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,"파일이 없습니다.");
+            }
+        }
+
+        return imageList;
+
+    }
+
+    // 파일 이름 암호화
+    public String createFileName(String fileName){
+        return UUID.randomUUID().toString().concat(getFileExtension(fileName));
+    }
+
+    private String getFileExtension(String fileName){
+        try{
+            return fileName.substring(fileName.lastIndexOf("."));
+        } catch (StringIndexOutOfBoundsException e){
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "잘못된 형식의 파일" + fileName + ") 입니다.");
+        }
+    }
+
+
+    //파일 삭제
+    public void deleteFile(String originFileName){
+        DeleteObjectRequest request = new DeleteObjectRequest(bucket,originFileName);
+        amazonS3.deleteObject(request);
+    }
+
+
+
+}

--- a/src/main/java/com/campro/s3/presentation/controller/S3Controller.java
+++ b/src/main/java/com/campro/s3/presentation/controller/S3Controller.java
@@ -1,0 +1,38 @@
+package com.campro.s3.presentation.controller;
+
+
+import com.campro.s3.application.DTO.ImageListDTO;
+import com.campro.s3.application.S3UploadService;
+import com.campro.s3.presentation.request.FileDeleteRequest;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/image")
+public class S3Controller {
+    
+    private final S3UploadService s3UploadService;
+
+    public S3Controller(S3UploadService s3UploadService) {
+        this.s3UploadService = s3UploadService;
+    }
+
+
+    //등록
+    @PostMapping
+    public String fileUpload(@RequestPart List<MultipartFile> file) throws IOException {
+        s3UploadService.saveFiles(file);
+        return "ok";
+    }
+
+
+    //삭제
+    @DeleteMapping
+    public String fileDel(@RequestBody FileDeleteRequest originFileName){
+       s3UploadService.deleteFile(originFileName.getFileName());
+       return "OK";
+    }
+}

--- a/src/main/java/com/campro/s3/presentation/request/FileDeleteRequest.java
+++ b/src/main/java/com/campro/s3/presentation/request/FileDeleteRequest.java
@@ -1,0 +1,25 @@
+package com.campro.s3.presentation.request;
+
+public class FileDeleteRequest {
+
+    private String fileName;
+
+
+    public FileDeleteRequest(String fileName) {
+        this.fileName = fileName;
+    }
+    public FileDeleteRequest(){
+    }
+
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    @Override
+    public String toString() {
+        return "FileDeleteRequest{" +
+                "fileName='" + fileName + '\'' +
+                '}';
+    }
+}


### PR DESCRIPTION
# 🔥 연관 이슈

- close #35 
 
# 🚀 작업 내용

- S3에 이미지 업로드하고 삭제하는 로직 구현했습니다.
- 동시에 여러개 파일을 등록하고, 삭제할때는 한 개씩 삭제하도록 했습니다.

# 💬 리뷰 중점사항

- 저는 수정 부분을 그냥 등록 삭제로 해결하는 것으로 생각했는데 수정이 꼭 필요한지 일단 궁금하고,
- 또한 이런 S3와 관련해서 테스트코드를 작성하려고 했는데 S3Mock을 또 따로 가져와서 사용해야 해서 코드가 지저분해지는 점 + 업로드 , 삭제와 같은 경우도 제 로직이 아니라 기존의 있는 로직들을 사용했기 때문에 테스트 효율이 낮다고 판단해서 작성하지 않았습니다. 이 점 참고 부탁드립니다.
- 더 필요한 기능들이 있다면 추가하겠습니다.